### PR TITLE
Fix data type after calling transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.0.4
+
+- Fix: Added transformed_data key in ctx in Tufy::Transform
+
 # v0.0.3
 
 - Added TU Code for Number of Days Past Due in Tufy::BuildAccountSegment::Constants

--- a/lib/tufy/transform.rb
+++ b/lib/tufy/transform.rb
@@ -3,6 +3,7 @@ module Tufy
     include LightService::Organizer
 
     def self.execute(ctx)
+      ctx[:transformed_data] = ''
       with(ctx).reduce(
         BuildHeaderSegment,
         BuildNameSegment,
@@ -12,8 +13,6 @@ module Tufy
         BuildAccountSegment,
         BuildEndOfSubjectSegment,
       )
-
-      ctx[:transformed_data]
     end
   end
 end

--- a/lib/tufy/version.rb
+++ b/lib/tufy/version.rb
@@ -1,3 +1,3 @@
 module Tufy
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
#### Changes proposed in this pull request:
1. Put back `ctx[:transformed_data] = ''` in `::execute` in `Tufy::Transform`
2. Fixed wrong value of `transform_data_result` in `TransunionServices::Transform` being returned by `Tufy.transform`
2. Bumped version to 0.0.4
3. Updated CHANGELOG.md

@neilmarion for approval before rebuilding gem