### PR TITLE
Change formatting of number_of_days_past_due in ::transform in Tufy::…

### DIFF
--- a/lib/tufy/build_account_segment.rb
+++ b/lib/tufy/build_account_segment.rb
@@ -75,7 +75,7 @@ module Tufy
         Constants::CASH_ADVANCE_BALANCE_TAG +
           FormatStrings::F2TS % raw_data[:cash_advance_balance].to_i.to_s.size + raw_data[:cash_advance_balance].to_i.to_s +
         Constants::NUMBER_OF_DAYS_PAST_DUE_TAG +
-          FormatStrings::F2TS % (FormatStrings::F3TS % raw_data[:number_of_days_past_due]).size + FormatStrings::F3TS % raw_data[:number_of_days_past_due] +
+          '03' + raw_data[:number_of_days_past_due].to_s +
         Constants::PAST_DUE_AMOUNT_TAG +
           FormatStrings::F2TS % raw_data[:past_due_amount].to_i.to_s.size + raw_data[:past_due_amount].to_i.to_s +
         Constants::INSTALLMENT_AMOUNT_TAG +


### PR DESCRIPTION
#### Changes proposed in this pull request:
1. Do not use `FormatStrings::F3TS` in `raw_data[:number_of_days_past_due]` in `line 78`, instead use actual `raw_data[:number_of_days_past_due]` value

##### Explanation:
- TU Code (090) when used with `FormatStrings::F3TS` gives error: `ArgumentError: invalid value for Integer(): "090"`
- Same with TU Codes (030, 060), they give out different string values when used with `FormatStrings::F3TS`, outputs `'024'` and `'048'` respectively

#### Another note:
In `line 78` of Tufy::BuildAccountSegment:
```
        Constants::NUMBER_OF_DAYS_PAST_DUE_TAG +
          '03' + raw_data[:number_of_days_past_due].to_s +
```

even if `raw_data[:number_of_days_past_due]` is a `String`, it will give an error: `no implicit conversion of nil into String` unless I call `#to_s` on it.