### PR TITLE
Create method to return TU past due codes instead of using constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.05
+
+- Create method to return TU past due codes instead of using constants
+
 # v0.0.4
 
 - Fix: Added transformed_data key in ctx in Tufy::Transform

--- a/lib/tufy/build_account_segment.rb
+++ b/lib/tufy/build_account_segment.rb
@@ -36,6 +36,17 @@ module Tufy
       ctx.transformed_data = ctx.transformed_data + transform(ctx).upcase
     end
 
+    def self.tu_past_due_code(days_past_due)
+      case days_past_due
+      when 0
+        0
+      when (1..30)
+        1
+      else
+        ((days_past_due - 1) / 30) * 30
+      end
+    end
+
     private
 
     def self.transform(ctx)
@@ -155,15 +166,6 @@ module Tufy
       YES = "Y"
       NO = "N"
       NOT_APPLICABLE = "A"
-
-      # TU Code for Number of Days Past Due
-      PAST_DUE_CODE_000 = '000'
-      PAST_DUE_CODE_001 = '001'
-      PAST_DUE_CODE_030 = '030'
-      PAST_DUE_CODE_060 = '060'
-      PAST_DUE_CODE_090 = '090'
-      PAST_DUE_CODE_120 = '120'
-      PAST_DUE_CODE_150 = '150'
     end
   end
 end

--- a/lib/tufy/version.rb
+++ b/lib/tufy/version.rb
@@ -1,3 +1,3 @@
 module Tufy
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
- Problems with formatting TU past due codes in `Tufy::BuildAccountSegment`, returning different values and having exceptions with `nil` when value is more than `180`

- Method should return TU past due code but without a leading `0` so it works properly when formatted with `FormatStrings::F2TS` and ``FormatStrings::F3TS`

@neilmarion for review