### PR TITLE
Specify a range for light-service version

### DIFF
--- a/tufy.gemspec
+++ b/tufy.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'tufy/version' 
+require 'tufy/version'
 Gem::Specification.new do |spec|
   spec.name          = "tufy"
   spec.version       = Tufy::VERSION
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "light-service", "0.4.0"
+  spec.add_dependency "light-service", ">= 0.4.0", "<= 0.11.0"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Use latest pre-1.0 version